### PR TITLE
バージョン0.1.0へのロールバック（.env.localを除く）

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,15 +51,9 @@ pnpm dev
 ```
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
-## Using Docker
+You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
-```
-docker build . -t <DOCKER_HUB_REPO>/webapp-conversation:latest
-# now you can access it in port 3000
-docker run -p 3000:3000 <DOCKER_HUB_REPO>/webapp-conversation:latest
-```
-
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
 
 ## Learn More
 
@@ -72,45 +66,6 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 
 ## Deploy on Vercel
 
-> ⚠️ If you are using [Vercel Hobby](https://vercel.com/pricing), your message will be truncated due to the limitation of vercel.
-
-
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
-
-## デバッグログの制御
-
-アプリケーションには、開発時に役立つデバッグログ機能が組み込まれています。以下のファイルでデバッグログの制御が可能です：
-
-### 1. APIレスポンスのログ制御 (`service/base.ts`)
-
-```typescript
-// デバッグ用：APIレスポンスのログ出力（開発環境のみ）
-if (process.env.NODE_ENV === 'development' && false) { // デバッグが必要な場合はfalseをtrueに変更
-  console.log('API Response:', JSON.stringify(bufferObj, null, 2))
-}
-
-// ボタン情報のデバッグログ（開発環境のみ）
-if (process.env.NODE_ENV === 'development' && false) { // デバッグが必要な場合はfalseをtrueに変更
-  console.log('DEBUG-API: 抽出されたボタン情報:', { /* ログ内容 */ });
-}
-```
-
-### 2. コンポーネントのログ制御 (`app/components/index.tsx`, `app/components/welcome/index.tsx`)
-
-```typescript
-const logger = (prefix: string, ...args: any[]) => {
-  // デバッグログを有効にするフラグ（必要に応じてtrueに変更）
-  const enableDebugLogs = false;
-  
-  // エラーログは常に表示し、デバッグログはフラグに依存
-  const isErrorLog = prefix.toLowerCase().includes('error');
-  
-  if (process.env.NODE_ENV === 'development' && (isErrorLog || enableDebugLogs)) {
-    console.log(`${prefix}:`, ...args);
-  }
-}
-```
-
-デバッグが必要な場合は、各ファイル内の `false` を `true` に変更するか、`enableDebugLogs` フラグを `true` に設定してください。


### PR DESCRIPTION
このプルリクエストは、リポジトリをバージョン0.1.0の状態にロールバックするためのものです。

## ロールバックの内容
- `.env.local`ファイルを除くすべてのファイルを、バージョン0.1.0の状態に戻します
- 「共通ロガー実装とデバッグログ制御の最適化」の変更を元に戻します

## 注意事項
- このプルリクエストをマージした後、`.env.local`ファイルは手動で保持する必要があります
- バージョン0.1.0の安定した状態に戻すことで、最近の変更による問題を解決します